### PR TITLE
[MP-009] Refactoring: matched scheduler-jobrunr with quartz design

### DIFF
--- a/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/jobs/handlers/pagination/PaginatedJobRequestHandler.kt
+++ b/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/jobs/handlers/pagination/PaginatedJobRequestHandler.kt
@@ -2,10 +2,11 @@ package io.scheduler.comparison.jobrunr.jobs.handlers.pagination
 
 import io.scheduler.comparison.jobrunr.jobs.state.JobState
 import io.scheduler.comparison.jobrunr.jobs.pagination.JobPaginator
+import io.scheduler.comparison.jobrunr.jobs.state.data.ChunkedJobMetadata
 import org.jobrunr.jobs.lambdas.JobRequest
 import org.jobrunr.jobs.lambdas.JobRequestHandler
 
-interface PaginatedJobRequestHandler<T : JobState<*, *>, V, K : JobRequest> : JobRequestHandler<K> {
+interface PaginatedJobRequestHandler<T : JobState<*, ChunkedJobMetadata>, V, K : JobRequest> : JobRequestHandler<K> {
 
     fun handleNextPage(paginator: JobPaginator<T, V>): Collection<V>
 

--- a/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/jobs/pagination/JobPaginator.kt
+++ b/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/jobs/pagination/JobPaginator.kt
@@ -1,8 +1,9 @@
 package io.scheduler.comparison.jobrunr.jobs.pagination
 
 import io.scheduler.comparison.jobrunr.jobs.state.JobState
+import io.scheduler.comparison.jobrunr.jobs.state.data.ChunkedJobMetadata
 
-interface JobPaginator<T : JobState<*, *>, V> : Iterator<List<V>> {
+interface JobPaginator<T : JobState<*, ChunkedJobMetadata>, V> : Iterator<List<V>> {
 
     val jobState: T
     val pageSize: Int

--- a/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/messaging/KafkaTemplateSenderBase.kt
+++ b/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/messaging/KafkaTemplateSenderBase.kt
@@ -1,0 +1,34 @@
+package io.scheduler.comparison.jobrunr.messaging
+
+import io.scheduler.comparison.jobrunr.config.properties.KafkaTopics
+import org.springframework.kafka.core.KafkaTemplate
+import java.util.concurrent.CompletableFuture
+
+abstract class KafkaTemplateSenderBase<T>(
+    private val kafkaTemplate: KafkaTemplate<String, Any>,
+    private val kafkaTopics: KafkaTopics
+) {
+
+    protected fun send(
+        topic: SupportedKafkaTopics,
+        messages: Collection<T>,
+        onSuccess: ((messages: Collection<T>) -> Unit)? = null,
+        onError: ((error: Throwable) -> Unit)? = null,
+    ): CompletableFuture<*> {
+        val targetTopic = kafkaTopics.topics[topic.value]
+            ?: throw IllegalArgumentException("Non-existent topic: ${topic.value}, "
+                    + "available: ${kafkaTopics.topics}")
+
+        return CompletableFuture.allOf(*messages.asSequence()
+            .map{ kafkaTemplate.send(targetTopic, it) }
+            .toList().toTypedArray()
+        ).whenComplete { _, throwable ->
+            if (throwable == null) {
+                onSuccess?.invoke(messages)
+            } else {
+                onError?.invoke(throwable)
+            }
+        }
+    }
+
+}

--- a/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/messaging/LocaLolaRefundsSender.kt
+++ b/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/messaging/LocaLolaRefundsSender.kt
@@ -5,36 +5,22 @@ import io.scheduler.comparison.jobrunr.config.properties.KafkaTopics
 import io.scheduler.comparison.jobrunr.domain.OrderRefund
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
-import java.util.concurrent.CompletableFuture
 
 @Component
 class LocaLolaRefundsSender(
-    private val kafkaTemplate: KafkaTemplate<String, Any>,
-    private val kafkaTopics: KafkaTopics
-) {
+    kafkaTemplate: KafkaTemplate<String, Any>,
+    kafkaTopics: KafkaTopics
+) : KafkaTemplateSenderBase<OrderRefund>(kafkaTemplate, kafkaTopics) {
 
     private companion object {
         val log = KotlinLogging.logger {}
     }
 
-    // Todo: throw custom exception if Kafka gives up
-    fun sendAllRefunds(refunds: List<OrderRefund>) {
-        // Todo: match batch size of actual Kafka batch on the KafkaTemplate
-
-        val targetTopic = kafkaTopics.topics[SupportedKafkaTopics.LOCA_LOLA_REFUNDS.value]
-            ?: throw IllegalArgumentException("Non-existent topic: ${SupportedKafkaTopics.LOCA_LOLA_REFUNDS.value}, "
-                    + "available: ${kafkaTopics.topics}")
-
-        CompletableFuture.allOf(*refunds.asSequence()
-            .map{ kafkaTemplate.send(targetTopic, it) }
-            .toList().toTypedArray()
-        ).whenComplete { _, throwable ->
-            if (throwable == null) {
-                log.info { "Successfully sent ${refunds.size} Loca-Lola refunds" }
-            } else {
-                log.warn { "Failed sending Loca-Lola refunds, cause: ${throwable.message}" }
-            }
-        }
-    }
+    fun sendOrderRefunds(orderRefunds: Collection<OrderRefund>) = send(
+        topic = SupportedKafkaTopics.LOCA_LOLA_REFUNDS,
+        messages = orderRefunds,
+        onSuccess = { messages -> log.info { "Successfully sent ${messages.size} Loca-Lola refunds" } },
+        onError = { throwable -> log.warn { "Failed sending Loca-Lola refunds, cause: ${throwable.message}" } },
+    )
 
 }

--- a/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/messaging/NotificationPlatformSender.kt
+++ b/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/messaging/NotificationPlatformSender.kt
@@ -3,16 +3,14 @@ package io.scheduler.comparison.jobrunr.messaging
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.scheduler.comparison.jobrunr.config.properties.KafkaTopics
 import io.scheduler.comparison.jobrunr.domain.OperationOnOrder
-import io.scheduler.comparison.jobrunr.domain.OrderRefund
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
-import java.util.concurrent.CompletableFuture
 
 @Component
 class NotificationPlatformSender(
-    private val kafkaTemplate: KafkaTemplate<String, Any>,
-    private val kafkaTopics: KafkaTopics
-) {
+    kafkaTemplate: KafkaTemplate<String, Any>,
+    kafkaTopics: KafkaTopics
+) : KafkaTemplateSenderBase<OperationOnOrder>(kafkaTemplate, kafkaTopics) {
 
     private companion object {
         val log = KotlinLogging.logger {}
@@ -24,34 +22,5 @@ class NotificationPlatformSender(
         onSuccess = { orders -> log.info { "Successfully sent ${orders.size} operations on order to Notification platform" } },
         onError = { throwable -> log.warn { "Failed sending operations on order to Notification platform, cause: ${throwable.message}" } }
     )
-
-    fun sendOrderRefunds(orderRefunds: Collection<OrderRefund>) = send(
-        topic = SupportedKafkaTopics.LOCA_LOLA_REFUNDS,
-        messages = orderRefunds,
-        onSuccess = { messages -> log.info { "Successfully sent ${messages.size} Loca-Lola refunds" } },
-        onError = { throwable -> log.warn { "Failed sending Loca-Lola refunds, cause: ${throwable.message}" } },
-    )
-
-    private fun <T> send(
-        topic: SupportedKafkaTopics,
-        messages: Collection<T>,
-        onSuccess: ((messages: Collection<T>) -> Unit)? = null,
-        onError: ((error: Throwable) -> Unit)? = null,
-    ): CompletableFuture<*> {
-        val targetTopic = kafkaTopics.topics[topic.value]
-            ?: throw IllegalArgumentException("Non-existent topic: ${topic.value}, "
-                    + "available: ${kafkaTopics.topics}")
-
-        return CompletableFuture.allOf(*messages.asSequence()
-            .map{ kafkaTemplate.send(targetTopic, it) }
-            .toList().toTypedArray()
-        ).whenComplete { _, throwable ->
-            if (throwable == null) {
-                onSuccess?.invoke(messages)
-            } else {
-                onError?.invoke(throwable)
-            }
-        }
-    }
 
 }

--- a/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/service/TransactionalPaginatedService.kt
+++ b/scheduler-jobrunr/src/main/kotlin/io/scheduler/comparison/jobrunr/service/TransactionalPaginatedService.kt
@@ -3,8 +3,9 @@ package io.scheduler.comparison.jobrunr.service
 import arrow.core.Either
 import io.scheduler.comparison.jobrunr.jobs.pagination.JobPaginator
 import io.scheduler.comparison.jobrunr.jobs.state.JobState
+import io.scheduler.comparison.jobrunr.jobs.state.data.ChunkedJobMetadata
 
-interface TransactionalPaginatedService<T : JobState<*, *>, V, E : Throwable> {
+interface TransactionalPaginatedService<T : JobState<*, ChunkedJobMetadata>, V, E : Throwable> {
 
     fun processNextPageTransactionally(paginator: JobPaginator<T, V>): Either<E, List<V>>
 


### PR DESCRIPTION
* Added stricter generic type bounds for JobPaginator: JobState now requires ChunkedJobMetadata
* Kafka now uses a common base sender class